### PR TITLE
Improving screen reader accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rubric Creator by [The Graide Network](https://www.thegraidenetwork.com/)
 
-Create and share scoring rubrics for grading papers. Made for educators by [The Graide Network](https://www.thegraidenetwork.com/) and available for free at [rubriccreator.com](https://rubriccreator.com).
+Create and share scoring rubrics for grading papers. Made for educators by [The Graide Network](https://www.thegraidenetwork.com/) and available for free at [rubriccreator.com](https://www.rubriccreator.com).
 
 [![Codeship Status for thegraidenetwork/rubric-creator](https://app.codeship.com/projects/95a16760-27a5-0136-f837-6ef2b9ae3ded/status?branch=master)](https://app.codeship.com/projects/287071)
 

--- a/src/app/components/edit-rubric-header/edit-rubric-header.component.html
+++ b/src/app/components/edit-rubric-header/edit-rubric-header.component.html
@@ -1,6 +1,8 @@
 <div *ngIf="rubric" class="row">
     <div class="col-12">
         <h1>Create New Rubric</h1>
+        <p><span class="text-danger">*</span>Indicates required field.</p>
+        <hr/>
         <div class="form-group">
             <label for="rubric-name">Name<span class="text-danger">*</span></label>
             <input

--- a/src/app/components/edit-rubric-save-button/edit-rubric-save-button.component.html
+++ b/src/app/components/edit-rubric-save-button/edit-rubric-save-button.component.html
@@ -1,6 +1,5 @@
 <div class="row" *ngIf="rubric">
     <div class="col mt-4 mb-4">
-        <p><span class="text-danger">*</span>Indicates required field.</p>
         <button
                 type="submit"
                 class="btn btn-primary btn-block btn-lg"

--- a/src/app/components/rubric-action-button-group/rubric-action-button-group.component.html
+++ b/src/app/components/rubric-action-button-group/rubric-action-button-group.component.html
@@ -1,33 +1,25 @@
 <div class="btn-group d-print-none" [class.float-md-right]="floatRight" role="group">
-    <div aria-label="Action buttons">
-      <button (click)="copyLink()" type="button" class="btn btn-secondary">
-        <span *ngIf="!copied" [ngbTooltip]="'Copy Link'" class="oi oi-link-intact" aria-label="Copy Link"></span>
-        <span *ngIf="copied" [ngbTooltip]="'Link Copied!'" class="oi oi-check" aria-label="Link Copied"></span>
-      </button>
-      <button *ngIf="rubric.uuid"
-              type="button"
-              class="btn btn-secondary"
-              [routerLink]="'/rubrics/' + rubric.uuid + '/duplicate'">
-        <span [ngbTooltip]="'Duplicate Rubric'" class="oi oi-layers" aria-label="Duplicate Rubric"></span>
-      </button>
-      <button *ngIf="showPrint" type="button" class="btn btn-secondary" (click)="printRubric()">
-        <span [ngbTooltip]="'Print/Download Rubric'" class="oi oi-print" aria-label="Print/Download Rubric"></span>
-      </button>
-      <button *ngIf="rubric.private" type="button" class="btn btn-secondary" (click)="openDeleteRubricModal()">
-        <span [ngbTooltip]="'Delete Rubric'" class="oi oi-trash" aria-label="Delete Rubric"></span>
-      </button>
-      <button *ngIf="!rubric.private" type="button" class="btn btn-secondary disabled">
-        <span [ngbTooltip]="'Public'" class="oi oi-lock-unlocked" aria-label="Public"></span>
-      </button>
-      <button *ngIf="rubric.private" type="button" class="btn btn-secondary disabled">
-        <span [ngbTooltip]="'Private'" class="oi oi-lock-locked" aria-label="Private"></span>
-      </button>
-    </div>
-    <span *ngIf="rubric.created_at" 
-          [class.extra-wide]="!rubric.private" 
-          class="d-none d-lg-block btn btn-outline-secondary disabled btn-date"
-          aria-label="Date Created">
-          {{ rubric.created_at | date: 'mediumDate' }}
-    </span>
+  <button (click)="copyLink()" type="button" class="btn btn-secondary">
+    <span *ngIf="!copied" [ngbTooltip]="'Copy Link'" class="oi oi-link-intact" aria-label="Copy Link"></span>
+    <span *ngIf="copied" [ngbTooltip]="'Link Copied!'" class="oi oi-check" aria-label="Link Copied"></span>
+  </button>
+  <button *ngIf="rubric.uuid" type="button" class="btn btn-secondary" [routerLink]="'/rubrics/' + rubric.uuid + '/duplicate'">
+    <span [ngbTooltip]="'Duplicate Rubric'" class="oi oi-layers" aria-label="Duplicate Rubric"></span>
+  </button>
+  <button *ngIf="showPrint" type="button" class="btn btn-secondary" (click)="printRubric()">
+    <span [ngbTooltip]="'Print/Download Rubric'" class="oi oi-print" aria-label="Print/Download Rubric"></span>
+  </button>
+  <button *ngIf="rubric.private" type="button" class="btn btn-secondary" (click)="openDeleteRubricModal()">
+    <span [ngbTooltip]="'Delete Rubric'" class="oi oi-trash" aria-label="Delete Rubric"></span>
+  </button>
+  <span *ngIf="rubric.created_at" [class.extra-wide]="!rubric.private" class="d-none d-lg-block btn btn-outline-secondary disabled btn-date"
+    role="Date Created" tabindex="0">
+    {{ rubric.created_at | date: 'mediumDate' }}
+  </span>
+  <div *ngIf="!rubric.private" class="btn btn-secondary disabled">
+    <span [ngbTooltip]="'Public'" class="oi oi-lock-unlocked" role="Rubric Public" tabindex="0"></span>
   </div>
-  
+  <div *ngIf="rubric.private" class="btn btn-secondary disabled">
+    <span [ngbTooltip]="'Private'" class="oi oi-lock-locked" role="Rubric Private" tabindex="0"></span>
+  </div>
+</div>

--- a/src/app/components/rubric-action-button-group/rubric-action-button-group.component.html
+++ b/src/app/components/rubric-action-button-group/rubric-action-button-group.component.html
@@ -1,28 +1,33 @@
-<div class="btn-group d-print-none" [class.float-md-right]="floatRight" role="group" aria-label="Action buttons">
-  <button (click)="copyLink()" type="button" class="btn btn-secondary">
-    <span *ngIf="!copied" [ngbTooltip]="'Copy Link'" class="oi oi-link-intact"></span>
-    <span *ngIf="copied" [ngbTooltip]="'Link Copied!'" class="oi oi-check"></span>
-  </button>
-  <button *ngIf="rubric.uuid"
-          type="button"
-          class="btn btn-secondary"
-          [routerLink]="'/rubrics/' + rubric.uuid + '/duplicate'">
-    <span [ngbTooltip]="'Duplicate Rubric'" class="oi oi-layers"></span>
-  </button>
-  <button *ngIf="showPrint" type="button" class="btn btn-secondary" (click)="printRubric()">
-    <span [ngbTooltip]="'Print/Download Rubric'" class="oi oi-print"></span>
-  </button>
-  <button *ngIf="rubric.private" type="button" class="btn btn-secondary" (click)="openDeleteRubricModal()">
-    <span [ngbTooltip]="'Delete Rubric'" class="oi oi-trash"></span>
-  </button>
-  <button *ngIf="rubric.created_at" [class.extra-wide]="!rubric.private"
-          type="button" class="d-none d-lg-block btn btn-outline-secondary disabled btn-date">
-    {{ rubric.created_at | date: 'mediumDate' }}
-  </button>
-  <button *ngIf="!rubric.private" type="button" class="btn btn-secondary disabled">
-    <span [ngbTooltip]="'Public'" class="oi oi-lock-unlocked"></span>
-  </button>
-  <button *ngIf="rubric.private" type="button" class="btn btn-secondary disabled">
-    <span [ngbTooltip]="'Private'" class="oi oi-lock-locked"></span>
-  </button>
-</div>
+<div class="btn-group d-print-none" [class.float-md-right]="floatRight" role="group">
+    <div aria-label="Action buttons">
+      <button (click)="copyLink()" type="button" class="btn btn-secondary">
+        <span *ngIf="!copied" [ngbTooltip]="'Copy Link'" class="oi oi-link-intact" aria-label="Copy Link"></span>
+        <span *ngIf="copied" [ngbTooltip]="'Link Copied!'" class="oi oi-check" aria-label="Link Copied"></span>
+      </button>
+      <button *ngIf="rubric.uuid"
+              type="button"
+              class="btn btn-secondary"
+              [routerLink]="'/rubrics/' + rubric.uuid + '/duplicate'">
+        <span [ngbTooltip]="'Duplicate Rubric'" class="oi oi-layers" aria-label="Duplicate Rubric"></span>
+      </button>
+      <button *ngIf="showPrint" type="button" class="btn btn-secondary" (click)="printRubric()">
+        <span [ngbTooltip]="'Print/Download Rubric'" class="oi oi-print" aria-label="Print/Download Rubric"></span>
+      </button>
+      <button *ngIf="rubric.private" type="button" class="btn btn-secondary" (click)="openDeleteRubricModal()">
+        <span [ngbTooltip]="'Delete Rubric'" class="oi oi-trash" aria-label="Delete Rubric"></span>
+      </button>
+      <button *ngIf="!rubric.private" type="button" class="btn btn-secondary disabled">
+        <span [ngbTooltip]="'Public'" class="oi oi-lock-unlocked" aria-label="Public"></span>
+      </button>
+      <button *ngIf="rubric.private" type="button" class="btn btn-secondary disabled">
+        <span [ngbTooltip]="'Private'" class="oi oi-lock-locked" aria-label="Private"></span>
+      </button>
+    </div>
+    <span *ngIf="rubric.created_at" 
+          [class.extra-wide]="!rubric.private" 
+          class="d-none d-lg-block btn btn-outline-secondary disabled btn-date"
+          aria-label="Date Created">
+          {{ rubric.created_at | date: 'mediumDate' }}
+    </span>
+  </div>
+  

--- a/src/app/containers/edit-rubric/edit-rubric.component.html
+++ b/src/app/containers/edit-rubric/edit-rubric.component.html
@@ -4,7 +4,7 @@
             <rc-edit-rubric-header></rc-edit-rubric-header>
             <div class="row">
                 <div class="table-responsive">
-                    <table class="table table-striped">
+                    <table class="table table-striped" aria-label="Create Rubric Body">
                         <thead rc-rubric-table-head></thead>
                         <tbody rc-edit-rubric-table-body></tbody>
                     </table>

--- a/src/app/containers/edit-rubric/edit-rubric.component.html
+++ b/src/app/containers/edit-rubric/edit-rubric.component.html
@@ -4,7 +4,7 @@
             <rc-edit-rubric-header></rc-edit-rubric-header>
             <div class="row">
                 <div class="table-responsive">
-                    <table class="table table-striped" aria-label="Create Rubric Body">
+                    <table class="table table-striped" aria-label="Create Rubric Components and Levels">
                         <thead rc-rubric-table-head></thead>
                         <tbody rc-edit-rubric-table-body></tbody>
                     </table>


### PR DESCRIPTION
This is helping with #9. I used the Mac VoiceOver screen reader to go through everything line by line. Here is a little summary of my changes:

- I moved the "*Indicates required field warning" to the top of the **edit-rubric-header** component because you need to understand that information before navigating through the form.
- I added an `aria-label` to the table in the **edit-rubric** component because it's very unclear what the context of that table is when it's read out loud.
- In the **rubric-action-button-group** I added missing `aria-label`s to the buttons. I also changed the date created to a `<span>` because it's not actually button and moved it out of the `action-buttons` group.

There are two other major issues:

- When you navigate to each page the title is read first and then the focus does not move logically from the top of the page down, it starts on a random element.
- On the Create Rubric page when you create a new component the focus should automatically move to that new component. Currently you have to tab up 37 times to get to it.

I started teaching myself Angular over the weekend but I don't understand it well enough to tackle those issues yet. This is my first open source contribution so hopefully I did this right!